### PR TITLE
Specify that the main.js is encoded in utf-8 

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,6 +39,9 @@ app.use('/', function (req, res, next) {
     res.setHeader('Content-Type', 'text/javascript');
     fs.createReadStream(path.join(__dirname, 'cozy.js'))
       .pipe(res);
+  } else if (req.url === '/scripts/main.js'){
+    res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
+    next();
   } else if (/main.js/.test(req.url)) {
     console.log(req.url);
     main = req.url.split('/').pop();
@@ -49,9 +52,6 @@ app.use('/', function (req, res, next) {
       // hotfix of a bug in Laverna
       .pipe(replaceStream('notebookId:{type:"string"}', 'notebookId:{type:"number"}'))
       .pipe(res);
-  } else if (req.url === '/scripts/main.js'){
-    res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
-    next();
   } else {    
     next();
   }

--- a/server.js
+++ b/server.js
@@ -49,7 +49,7 @@ app.use('/', function (req, res, next) {
       // hotfix of a bug in Laverna
       .pipe(replaceStream('notebookId:{type:"string"}', 'notebookId:{type:"number"}'))
       .pipe(res);
-  } else if (req.url === '/main.js'){
+  } else if (req.url === '/scripts/main.js'){
     res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
   } else {    
     next();

--- a/server.js
+++ b/server.js
@@ -49,7 +49,9 @@ app.use('/', function (req, res, next) {
       // hotfix of a bug in Laverna
       .pipe(replaceStream('notebookId:{type:"string"}', 'notebookId:{type:"number"}'))
       .pipe(res);
-  } else {
+  } else if (req.url === '/main.js'){
+    res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
+  } else {    
     next();
   }
 });

--- a/server.js
+++ b/server.js
@@ -51,6 +51,7 @@ app.use('/', function (req, res, next) {
       .pipe(res);
   } else if (req.url === '/scripts/main.js'){
     res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
+    next();
   } else {    
     next();
   }


### PR DESCRIPTION
For recent installation of laverna, the installed client is in version 0.7.x
The new main.js is now encoded in UTF-8, it is necessary to specify the encoding, otherwise the client crashes when trying to put a new note.
The solution might not be clean, but works :p 
I can rebase for a single commit (dev from github code editor is not efficient)